### PR TITLE
Improving .htaccess

### DIFF
--- a/example.htaccess
+++ b/example.htaccess
@@ -1,9 +1,6 @@
 # Turn on URL rewriting
 RewriteEngine On
 
-# Installation directory
-RewriteBase /
-
 # Protect hidden files from being viewed
 <Files .*>
 	Order Deny,Allow
@@ -18,4 +15,4 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 
 # Rewrite all other URLs to index.php/URL
-RewriteRule .* index.php/$0 [PT]
+RewriteRule ^(.*)$ index.php/$0 [PT]


### PR DESCRIPTION
I get an 403 error when I install Kohana in any folder other than `/` and I try to go to any URL other than `/`.

This can be fixed by removing the `rewrite base` and replacing `.*` with `^(.*)$` in the rewrite rule of the `.htaccess` file.
